### PR TITLE
Refresh fresh+link hero and OSS copy for link 0.7.0

### DIFF
--- a/content/project/open_source_software/index.md
+++ b/content/project/open_source_software/index.md
@@ -5,19 +5,21 @@ layout: single
 weight: 3
 ---
 
-Our data, analytical tools, and methods are publicly available on GitHub — built in R, Python, SQL, shell, OpenTofu, and GitHub Actions. We work in the open wherever transparency improves science. The packages highlighted here are designed to work together — network analysis feeds floodplain delineation, historic imagery feeds change detection, and field data flows through to published reports.
+Our data, analytical tools, and methods are publicly available on GitHub — built in R, Python, SQL, shell, OpenTofu, and GitHub Actions. We work in the open wherever transparency improves science. The packages highlighted here are designed to work together — point data (observations, eDNA, field surveys) and network-joinable attributes (temperature, channel width, climate) feed fresh + link's modelling core, which in turn feeds floodplain delineation, land cover change detection, and climate analysis, all rendered as interactive reports and print-ready PDFs.
 
 <br>
 
 ## Watershed Modelling
 
-Composable tools for understanding watersheds — habitat classification, barrier prioritization, floodplain delineation, land cover change, historic condition, and climate trends. Built on the Freshwater Atlas and designed to work alongside provincial connectivity models.
+Composable tools for understanding watersheds — per-species habitat classification, connectivity modelling, barrier interpretation, floodplain delineation, land cover change, historic condition, and climate trends. Built on the Freshwater Atlas, portable to any stream network.
 
 <img src="/img/hex/fresh.png" alt="fresh" style="float: right; width: 100px; margin: 0 0 1rem 1.5rem;">
 
 ### fresh — Freshwater Referenced Spatial Hydrology
 
-A composable stream network modelling engine. Query and extract stream networks, classify habitat by gradient and channel width, segment networks at barriers and break points, aggregate features upstream or downstream, and run multi-species habitat modelling with parallel workers. Supports custom model outputs and attribute joining — channel width, mean annual discharge, precipitation, or any scalar value. Currently running on BC's Freshwater Atlas, designed to model fish habitat, connectivity, water temperature, channel morphology, and custom attributes for any species or question on any stream network.
+A composable stream network modelling engine. Segment networks at break points, classify per-species habitat against any network-joinable attribute (gradient, channel width, temperature, discharge, climate departures), cluster for connectivity, and aggregate upstream or downstream with parallel workers.
+
+Running on BC's Freshwater Atlas today, designed for any stream network — provincial atlases, LiDAR-derived networks from our STAC DEM catalogue, or other jurisdictions.
 
 - [Documentation](https://www.newgraphenvironment.com/fresh/) | [Source](https://github.com/NewGraphEnvironment/fresh)
 
@@ -33,7 +35,9 @@ A composable stream network modelling engine. Query and extract stream networks,
 
 ### link — Watershed Point Interpretation
 
-Match, score, and interpret any point data on the stream network — crossing barriers, temperature monitoring stations, fish density sample sites, water quality stations, or traditional use locations. Column-agnostic and configurable: ship with BC fish passage defaults but work for any jurisdiction or data type. Produces break source specs that fresh consumes directly, and reads fresh output back for per-point upstream habitat rollup. Currently powering fish passage prioritization across the province, with the same architecture ready for any network-referenced analysis.
+The interpretation layer. Load, match, and score any point data on the stream network — fish-passage barriers, observations, eDNA detections, fisheries density samples, thermal loggers, water quality stations, traditional use locations — with bidirectional deduplication, provenance tracking, and expert-override workflows.
+
+Orchestrates end-to-end species-habitat pipelines via config bundles: one bundle per method or jurisdiction. Ships with BC fish-passage defaults; swap the bundle to express alternative methods, add new species, or move to another jurisdiction. Produces the break sources and per-species override skip-lists that drive fresh's engine, and reads fresh output back for per-point upstream habitat rollup.
 
 - [Documentation](https://www.newgraphenvironment.com/link/) | [Source](https://github.com/NewGraphEnvironment/link)
 
@@ -45,7 +49,9 @@ Match, score, and interpret any point data on the stream network — crossing ba
 
 ### flooded — Floodplain Delineation
 
-Delineate functional floodplains from DEMs and stream networks using the Valley Confinement Algorithm. Identify where floodplains are intact, confined, or disconnected — the areas where rivers do geomorphic work including sediment storage, nutrient exchange, and riparian recruitment.
+Delineate functional floodplains from any DEM and stream network using the Valley Confinement Algorithm — slope thresholding, cost-distance analysis, and flood-surface modelling with a bankfull regression. DEM-agnostic: bring your own source, from provincial TRIM to 1 m LiDAR from our STAC DEM catalogue.
+
+The resolution gap is itself a diagnostic. Coarse DEMs show the floodplain surface; fine DEMs expose the roads, rail grades, dykes, and agricultural fill that sit above that surface and block lateral connectivity. Comparing the two shows **what is preventing floodplain from functioning, and where to act** — fill removal, dyke breaches, crossing installations.
 
 - [Documentation](https://www.newgraphenvironment.com/flooded/) | [Source](https://github.com/NewGraphEnvironment/flooded)
 
@@ -61,7 +67,9 @@ Delineate functional floodplains from DEMs and stream networks using the Valley 
 
 ### drift — Detecting Riparian and Inland Floodplain Transitions
 
-Fetch satellite-derived land cover data from STAC catalogs and track what's changing inside floodplains over time. Multi-year analysis from Esri IO LULC and ESA WorldCover. Integrates with flooded to focus change detection on the ecologically relevant floodplain extent.
+Fetch classified land cover rasters from STAC catalogs — Esri IO LULC, ESA WorldCover, or custom COGs — apply class labels and colours, and summarise area change over time. Works at global satellite resolution (10 m IO LULC) or sub-metre UAV classifications from our `stac_uav_bc` catalogue.
+
+Queries run server-side via `gdalcubes` — crop before download, not after. Serves tiles through `titiler` for on-the-fly visualisation of massive rasters. Pair with flooded for within-floodplain analysis, or use on its own for any polygonal AOI.
 
 - [Documentation](https://www.newgraphenvironment.com/drift/) | [Source](https://github.com/NewGraphEnvironment/drift)
 
@@ -146,6 +154,8 @@ This data feeds into collaborative science with [Poisson Consulting](https://www
 We assemble reproducible, field-ready GIS projects for any watershed in British Columbia. Provincial datasets from the BC Data Catalogue, Freshwater Atlas, and our cloud-hosted layers are pulled, clipped to project boundaries, and delivered as fully styled QGIS projects with digital field forms — ready to deploy to mobile devices for collaborative offline collection.
 
 We maintain forms for fish passage assessment, habitat confirmation, effectiveness monitoring, restoration site investigation, eDNA sampling, and benthic invertebrate collection, and add new ones as programs evolve. Where possible, collected data is structured for direct submission to provincial database systems (FISS, PSCIS, CABIN); other data lands in central database systems we maintain and share with partners. Photos are automatically renamed and organized into site directories. Multiple team members contribute within the same shared project, with changes syncing between field and office.
+
+Collected data lands back in the same pipeline it came from — fish passage assessments feed link's barrier interpretation layer; eDNA detections and benthic samples join the network as point attributes; habitat confirmations become overrides on fresh's classification. Field-to-network-to-report, closed loop.
 
 <br>
 

--- a/content/project/open_source_software/index.md
+++ b/content/project/open_source_software/index.md
@@ -37,7 +37,7 @@ Running on BC's Freshwater Atlas today, designed to work on any stream network �
 
 Connects field data to the stream network and interprets what it means. Load, match, and score any point data — fish-passage barriers, observations, eDNA detections, density samples, thermal loggers, water quality stations, traditional use locations — and track where each record came from and how it was corrected.
 
-link ships with BC fish-passage defaults but is designed to swap in different rules for another watershed, species, or jurisdiction. It feeds fresh the break points and barrier lists it needs to classify habitat, and reads fresh's output back to summarise habitat above each field site.
+Feeds fresh the break points and barrier lists it needs to classify habitat, and reads fresh's output back to summarise habitat above each field site.
 
 - [Documentation](https://www.newgraphenvironment.com/link/) | [Source](https://github.com/NewGraphEnvironment/link)
 

--- a/content/project/open_source_software/index.md
+++ b/content/project/open_source_software/index.md
@@ -5,7 +5,7 @@ layout: single
 weight: 3
 ---
 
-Our data, analytical tools, and methods are publicly available on GitHub — built in R, Python, SQL, shell, OpenTofu, and GitHub Actions. We work in the open wherever transparency improves science. The packages highlighted here are designed to work together — point data (observations, eDNA, field surveys) and network-joinable attributes (temperature, channel width, climate) feed fresh + link's modelling core, which in turn feeds floodplain delineation, land cover change detection, and climate analysis, all rendered as interactive reports and print-ready PDFs.
+Our data, analytical tools, and methods are publicly available on GitHub — built in R, Python, SQL, shell, OpenTofu, and GitHub Actions. We work in the open wherever transparency improves science. The packages highlighted here are designed to work together — field data (observations, eDNA, barriers) and stream measurements (temperature, channel width, climate) feed fresh and link, which produce habitat and connectivity models for the watershed. Those outputs then drive floodplain delineation, land cover change detection, and climate analysis, all rendered as interactive reports and print-ready PDFs.
 
 <br>
 
@@ -17,9 +17,9 @@ Composable tools for understanding watersheds — per-species habitat classifica
 
 ### fresh — Freshwater Referenced Spatial Hydrology
 
-A composable stream network modelling engine. Segment networks at break points, classify per-species habitat against any network-joinable attribute (gradient, channel width, temperature, discharge, climate departures), cluster for connectivity, and aggregate upstream or downstream with parallel workers.
+A stream network modelling engine. Classify habitat for any species using any measurable stream attribute — gradient, channel width, temperature, discharge, climate departures — break the network at barriers or falls, and summarise habitat upstream or downstream of any point on the network.
 
-Running on BC's Freshwater Atlas today, designed for any stream network — provincial atlases, LiDAR-derived networks from our STAC DEM catalogue, or other jurisdictions.
+Running on BC's Freshwater Atlas today, designed to work on any stream network — other provincial atlases, LiDAR-derived networks from our STAC DEM catalogue, or streams in other jurisdictions.
 
 - [Documentation](https://www.newgraphenvironment.com/fresh/) | [Source](https://github.com/NewGraphEnvironment/fresh)
 
@@ -35,9 +35,9 @@ Running on BC's Freshwater Atlas today, designed for any stream network — prov
 
 ### link — Watershed Point Interpretation
 
-The interpretation layer. Load, match, and score any point data on the stream network — fish-passage barriers, observations, eDNA detections, fisheries density samples, thermal loggers, water quality stations, traditional use locations — with bidirectional deduplication, provenance tracking, and expert-override workflows.
+Connects field data to the stream network and interprets what it means. Load, match, and score any point data — fish-passage barriers, observations, eDNA detections, density samples, thermal loggers, water quality stations, traditional use locations — and track where each record came from and how it was corrected.
 
-Orchestrates end-to-end species-habitat pipelines via config bundles: one bundle per method or jurisdiction. Ships with BC fish-passage defaults; swap the bundle to express alternative methods, add new species, or move to another jurisdiction. Produces the break sources and per-species override skip-lists that drive fresh's engine, and reads fresh output back for per-point upstream habitat rollup.
+link ships with BC fish-passage defaults but is designed to swap in different rules for another watershed, species, or jurisdiction. It feeds fresh the break points and barrier lists it needs to classify habitat, and reads fresh's output back to summarise habitat above each field site.
 
 - [Documentation](https://www.newgraphenvironment.com/link/) | [Source](https://github.com/NewGraphEnvironment/link)
 
@@ -49,9 +49,9 @@ Orchestrates end-to-end species-habitat pipelines via config bundles: one bundle
 
 ### flooded — Floodplain Delineation
 
-Delineate functional floodplains from any DEM and stream network using the Valley Confinement Algorithm — slope thresholding, cost-distance analysis, and flood-surface modelling with a bankfull regression. DEM-agnostic: bring your own source, from provincial TRIM to 1 m LiDAR from our STAC DEM catalogue.
+Delineate functional floodplains from any elevation model and stream network using the Valley Confinement Algorithm — slope thresholding, cost-distance analysis, and flood-surface modelling with a bankfull regression. Works with any elevation source, from provincial TRIM to 1 m LiDAR from our STAC DEM catalogue.
 
-The resolution gap is itself a diagnostic. Coarse DEMs show the floodplain surface; fine DEMs expose the roads, rail grades, dykes, and agricultural fill that sit above that surface and block lateral connectivity. Comparing the two shows **what is preventing floodplain from functioning, and where to act** — fill removal, dyke breaches, crossing installations.
+The difference between coarse and fine elevation data is itself a diagnostic. Coarse data shows the floodplain surface; fine-resolution LiDAR exposes the roads, rail grades, dykes, and agricultural fill that sit above that surface and block lateral connectivity. Comparing the two shows **what is preventing floodplain from functioning, and where to act** — fill removal, dyke breaches, crossing installations.
 
 - [Documentation](https://www.newgraphenvironment.com/flooded/) | [Source](https://github.com/NewGraphEnvironment/flooded)
 
@@ -67,9 +67,9 @@ The resolution gap is itself a diagnostic. Coarse DEMs show the floodplain surfa
 
 ### drift — Detecting Riparian and Inland Floodplain Transitions
 
-Fetch classified land cover rasters from STAC catalogs — Esri IO LULC, ESA WorldCover, or custom COGs — apply class labels and colours, and summarise area change over time. Works at global satellite resolution (10 m IO LULC) or sub-metre UAV classifications from our `stac_uav_bc` catalogue.
+Fetch classified land cover rasters from STAC catalogs — Esri IO LULC, ESA WorldCover, or custom sources — apply class labels and colours, and summarise area change over time. Works at global satellite resolution (10 m IO LULC) or the sub-metre UAV classifications from our `stac_uav_bc` catalogue.
 
-Queries run server-side via `gdalcubes` — crop before download, not after. Serves tiles through `titiler` for on-the-fly visualisation of massive rasters. Pair with flooded for within-floodplain analysis, or use on its own for any polygonal AOI.
+Queries crop the data before download, not after — so province-scale areas of interest do not require full-tile fetches. Interactive tiles are served through `titiler` for on-the-fly visualisation of massive rasters. Pair with flooded for within-floodplain analysis, or use on its own for any area of interest.
 
 - [Documentation](https://www.newgraphenvironment.com/drift/) | [Source](https://github.com/NewGraphEnvironment/drift)
 
@@ -155,7 +155,7 @@ We assemble reproducible, field-ready GIS projects for any watershed in British 
 
 We maintain forms for fish passage assessment, habitat confirmation, effectiveness monitoring, restoration site investigation, eDNA sampling, and benthic invertebrate collection, and add new ones as programs evolve. Where possible, collected data is structured for direct submission to provincial database systems (FISS, PSCIS, CABIN); other data lands in central database systems we maintain and share with partners. Photos are automatically renamed and organized into site directories. Multiple team members contribute within the same shared project, with changes syncing between field and office.
 
-Collected data lands back in the same pipeline it came from — fish passage assessments feed link's barrier interpretation layer; eDNA detections and benthic samples join the network as point attributes; habitat confirmations become overrides on fresh's classification. Field-to-network-to-report, closed loop.
+Collected data flows back into the same pipeline it came from — fish passage assessments feed into link's barrier scoring; eDNA detections and benthic samples become new records on the stream network; habitat confirmations replace modelled classifications with field-verified ones. Field → network → report, closed loop.
 
 <br>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -314,8 +314,8 @@
               <img src="/img/hex/fresh.png" alt="fresh">
             </a>
             <div class="nge-pipeline-body">
-              <h3>Model any stream in BC</h3>
-              <p><strong>fresh</strong> (Freshwater Referenced Spatial Hydrology) — Query the provincial stream network, classify habitat, delineate watersheds, and model connectivity for any species.</p>
+              <h3>Model habitat and connectivity on any stream network</h3>
+              <p><strong>fresh</strong> (Freshwater Referenced Spatial Hydrology) — Segment networks, classify habitat against any attribute (gradient, channel width, temperature, discharge), and model connectivity for any species. Running on BC's Freshwater Atlas today, designed for any stream network.</p>
             </div>
           </div>
           <div class="nge-pipeline-step">
@@ -323,8 +323,8 @@
               <img src="/img/hex/link.png" alt="link">
             </a>
             <div class="nge-pipeline-body">
-              <h3>Score and prioritize</h3>
-              <p><strong>link</strong> (Watershed Point Interpretation) — Match, score, and interpret any point data on the stream network — barriers, monitoring stations, sample sites, or traditional use locations.</p>
+              <h3>Interpret any point data on the stream network</h3>
+              <p><strong>link</strong> (Watershed Point Interpretation) — Load, match, and score field features — barriers, observations, eDNA detections, thermal loggers, traditional use locations — then drive fresh's engine with per-species rules. Swap the config bundle to express any method or jurisdiction.</p>
             </div>
           </div>
         </div>
@@ -367,7 +367,7 @@
               <img src="/img/hex/cd.png" alt="cd">
             </a>
             <div class="nge-pipeline-body">
-              <h3>Assess climate trends</h3>
+              <h3>Quantify climate departures</h3>
               <p><strong>cd</strong> (Climate Departure) — Analyze temperature, precipitation, and soil moisture departures for any watershed using global reanalysis data.</p>
             </div>
           </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -315,7 +315,7 @@
             </a>
             <div class="nge-pipeline-body">
               <h3>Model habitat and connectivity on any stream network</h3>
-              <p><strong>fresh</strong> (Freshwater Referenced Spatial Hydrology) — Segment networks, classify habitat against any attribute (gradient, channel width, temperature, discharge), and model connectivity for any species. Running on BC's Freshwater Atlas today, designed for any stream network.</p>
+              <p><strong>fresh</strong> (Freshwater Referenced Spatial Hydrology) — Classify habitat and model connectivity for any species, using gradient, channel width, temperature, discharge, or any other stream measurement. Running on BC's Freshwater Atlas today, designed to work on any stream network.</p>
             </div>
           </div>
           <div class="nge-pipeline-step">
@@ -324,7 +324,7 @@
             </a>
             <div class="nge-pipeline-body">
               <h3>Interpret any point data on the stream network</h3>
-              <p><strong>link</strong> (Watershed Point Interpretation) — Load, match, and score field features — barriers, observations, eDNA detections, thermal loggers, traditional use locations — then drive fresh's engine with per-species rules. Swap the config bundle to express any method or jurisdiction.</p>
+              <p><strong>link</strong> (Watershed Point Interpretation) — Connect field data to the stream network — barriers, observations, eDNA detections, thermal loggers, traditional use locations — and hand it off to fresh for per-species habitat modelling. Ships with BC fish-passage defaults; different rule sets plug in for other watersheds, species, or jurisdictions.</p>
             </div>
           </div>
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -324,7 +324,7 @@
             </a>
             <div class="nge-pipeline-body">
               <h3>Interpret any point data on the stream network</h3>
-              <p><strong>link</strong> (Watershed Point Interpretation) — Connect field data to the stream network — barriers, observations, eDNA detections, thermal loggers, traditional use locations — and hand it off to fresh for per-species habitat modelling. Ships with BC fish-passage defaults; different rule sets plug in for other watersheds, species, or jurisdictions.</p>
+              <p><strong>link</strong> (Watershed Point Interpretation) — Connect field data to the stream network — barriers, observations, eDNA detections, thermal loggers, traditional use locations — and hand it off to fresh for per-species habitat modelling.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Reposition fresh + link in the hero pipeline and OSS page ahead of link 0.7.0 going public.
- Originates from a comms thread from link-Claude: `link/comms/newgraphenvironment.github.io/20260423_hero_fresh_link_positioning.md`.

### Hero edits (`layouts/index.html`)
- fresh: "Model any stream in BC" → "Model habitat and connectivity on any stream network"
- link: "Score and prioritize" → "Interpret any point data on the stream network"
- cd: "Assess climate trends" → "Quantify climate departures"
- Body copy reworked for both fresh and link; cd body unchanged.

### OSS page edits (`content/project/open_source_software/index.md`)
- Intro paragraph: reframed around point data + network-joinable attributes feeding fresh+link's modelling core.
- Watershed Modelling intro: dropped "designed to work alongside provincial connectivity models" hedging.
- `fresh` entry: leads with capability, splits the long sentence, notes portability.
- `link` entry: adds eDNA, fisheries density, thermal loggers; names the config bundle system and pipeline orchestration.
- `flooded` entry: adds the resolution-gap-as-diagnostic framing from flooded's own README.
- `drift` entry: adds custom COGs + `stac_uav_bc`, server-side `gdalcubes`, `titiler` tile serving.
- Field-to-Report: added a closing paragraph on the closed-loop back into link/fresh.

### Skipped from the proposal
- Climate-urgency "speed-of-response" framing — risked the no-speed-flex rule.
- DAG structural redraw — Al said no redraw; leaving the caption-only option as a separate iteration if desired.
- "Partnership science" standalone paragraph — the Poisson/Hillcrest credit is already in the water-temp-bc entry; elevate only if wanted.

## Test plan

- [ ] Visual review of hero pipeline row (fresh + link card, cd card)
- [ ] Visual review of OSS page Watershed Modelling section (fresh, link, flooded, drift entries)
- [ ] Confirm Field-to-Report closed-loop paragraph reads cleanly
- [ ] Merge to `main` to deploy via GitHub Pages workflow
- [ ] Close the comms thread with a short reply linking to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
